### PR TITLE
Adds base German instructions

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -41,6 +41,10 @@
     <div class="row">
       <h1>Hebräisch <small class="text-muted">Umschrift</small></h1>
       <p>
+        „Hebräisch Umschrift“ dient dazu, hebräische Wörter und Texte in deutsche Aussprache umzuwandeln. 
+        Die Anwendung entstand in einer Zusammenarbeit mit Rabbiner Zsolt Balla, Rabbiner der IRG Leipzig. 
+      </p>
+        <p>
         Hebräisch Umschrift is a UI for using the
         <code><a
               href="https://www.npmjs.com/package/umschrift"
@@ -51,21 +55,16 @@
         package. It serves to transliterate liturgical Hebrew into German
         orthography using a method developed in partnership with Rabbi Zsolt Balla, <a
           href="http://www.irg-leipzig.de/page/rabbiner">IRG Leipzig</a>
-      </p>
+      </p>      
       <br>
       <p>
-      <h4> Here's how it works:</h4>
-      </p>
-      <p>
-        1. Insert Hebrew text with <b>Nikkud.</b><br>
-        Hebrew text without Nikkud cannot produce proper vowel sounds. <br>
-        You can copy and paste any text from
-        <a href="https://www.sefaria.org/texts">Sefaria</a>,
-        <a href="https://www.mechon-mamre.org/i/t/t0.htm">Machon Mamre</a>,
-        <a href="https://www.stepbible.org/">Stepbible.org</a> or other preferred sources <br>
-        2. Click on the Transliterate button <br>
-        3. Copy transliteration for use<br>
-      </p>
+        <h3>Anleitung:</h3>
+        <p>
+          1. Fügen Sie den hebräischen Text mit dem „Nikkud“ (Pukntierung) in die leere Textfläche ein.<br>
+             <b>Bitte beachten Sie, dass ein Text ohne „Nikkud“ nicht die richtigen Vokale erzeugen wird.</b><br>
+          2. Klicken Sie auf die Schaltfläche „Transliterate“.<br>
+          3. Kopieren Sie die Transliteration zur Verwendung.
+        </p>
     </div>
     <div class="row justify-content-center">
       <div class="col-lg-6">
@@ -78,13 +77,29 @@
           style="font: italic 16px Charis SIL Compact, Charis SIL, Times New Roman, serif;"></textarea>
       </div>
     </div>
+      <h3> Here's how it works:</h3>
+      </p>
+      <p>
+        1. Insert Hebrew text with <b>Nikkud.</b><br>
+        Hebrew text without Nikkud cannot produce proper vowel sounds. <br>
+        You can copy and paste any text from
+        <a href="https://www.sefaria.org/texts">Sefaria</a>,
+        <a href="https://www.mechon-mamre.org/i/t/t0.htm">Machon Mamre</a>,
+        <a href="https://www.stepbible.org/">Stepbible.org</a> or other preferred sources <br>
+        2. Click on the Transliterate button <br>
+        3. Copy transliteration for use<br>
+      </p>
     <div class="row">
       <p><i>
           <font size="1">Additional Disclaimers<br>
             1. Some technical difficulties arise when using particular browsers, Safari or Firefox on Android devices.
             For best usage, use a Google Chrome browser. <br>
-            2. The divine name used is a direct transliteration of the pronuncination of the name. The tool does not
-            currently support other versions. We hope to expand options for Divine names in a future version.
+            2. The divine name used is the name used in liturgical services. The tool does not currently support other versions of preferred Divine names. We hope to expand options for Divine names in the future.
+        </i></font>
+      </p>
+      <p><i>
+          <font size="1">Zusätzliche Hinweise:<br>
+            Bei der Verwendung bestimmter Browser, wie Safari oder Firefox, auf Android-Geräten treten einige technische Schwierigkeiten auf. Verwenden Sie für eine optimale Verwendung den Google Chrome-Browser.
         </i></font>
       </p>
     </div>
@@ -107,5 +122,4 @@
     </div>
   </footer>
 </body>
-
 </html>


### PR DESCRIPTION
Changes around html and adds instructions of how to use tool in German. Moved English down to the bottom, as likely more German speakers will use this than English speakers. 